### PR TITLE
Fixed filenames composition error due to short CRC32 (0 padding)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 build
 pyoplm.egg-info
 .vscode/launch.json
+.vscode/settings.json

--- a/pyoplm/game.py
+++ b/pyoplm/game.py
@@ -135,7 +135,7 @@ class ULGame(Game):
         if hasattr(self, "filenames"):
             return self.filenames
         else:
-            crc32 = self.crc32[2:].upper()
+            crc32 = self.crc32[2:].upper().zfill(8)
             def part_format(part): return hex(part)[2:4].zfill(2).upper()
 
             self.filenames = [self.ulcfg.filedir.joinpath(


### PR DESCRIPTION
Hi, some games have a CRC32 code shorter than 8 chars.
For instance, Burnout 3 Takedown (EU) for PS2 on OPL is splitted into these data files:
ul.0B3043EA.SLES_525.85.00
ul.0B3043EA.SLES_525.85.01
ul.0B3043EA.SLES_525.85.02
ul.0B3043EA.SLES_525.85.03

Unfortunately, in such cases PyOPLM doesn't pad the CRC32 part of the name with the leading zeroes, thus generating names like this one:
ul.B3043EA.SLES_525.85.xx
and therefore it crashes for file not found.
Adding zeroes in front of the CRC32 code to reach 8 chars fixes this issue.