### PR TITLE
Add ZSO format support (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ The argument opl_dir is mostly required to be supplid by the commands of this ap
 OPL Directory in an environment variable named PYOPLM_OPL_DIR
 
 ```
-usage: pyoplm [-h] {list,rename,delete,fix,init,add,storage,bintools} ...
+usage: pyoplm [-h] {list,rename,delete,fix,init,add,storage,convert,bintools} ...
 
 positional arguments:
-  {list,rename,delete,fix,init,add,storage,bintools}
+  {list,rename,delete,fix,init,add,storage,convert,bintools}
                         Choose your path...
     list                List Games on OPL-Drive
     rename              Change the title of the game corresponding to opl_id
@@ -70,10 +70,20 @@ positional arguments:
     init                Initialize OPL folder structure
     add                 Add ISO/CUE PS2 and PSX game to opl_dir
     storage             Art and title storage-related functionality
+    convert             Convert between ISO and ZSO formats
     bintools            Tools for processing cue/bin games
 
 options:
   -h, --help            show this help message and exit
 ```
+
+### ZSO support
+
+OPL 1.2.0+ can load ZSO (LZ4-compressed ISO) files. Install a game directly
+as ZSO with `pyoplm add --zso <opl_dir> <game.iso>`, or convert existing
+files with `pyoplm convert --to-zso <game.iso>` /
+`pyoplm convert --to-iso <game.zso>`. ZSO files must be properly named
+(e.g. `SLUS_205.62.GameTitle.zso`), since the game ID cannot be read out of
+compressed data.
 
 Thank you danielb for the OPL Manager art database backups, great stuff

--- a/pyoplm/game.py
+++ b/pyoplm/game.py
@@ -18,6 +18,7 @@ class GameFormat(Enum):
     UL = "UL (USBExtreme)"
     ISO = "ISO"
     POPS = "VCD"
+    ZSO = "ZSO"
 
 
 class Game(ABC):
@@ -36,7 +37,7 @@ class Game(ABC):
     title: str
     size: float
     proper_filename_regex = re.compile(
-        r"^[HhMmPpGgNnCcSsJjTtBbDdAaKk][a-zA-Z]{3}.?\d{3}\.?\d{2}\..{1,32}\.([iI][sS][oO]|[vV][cC][dD])$")
+        r"^[HhMmPpGgNnCcSsJjTtBbDdAaKk][a-zA-Z]{3}.?\d{3}\.?\d{2}\..{1,32}\.([iI][sS][oO]|[vV][cC][dD]|[zZ][sS][oO])$")
 
     def __init__(self, filepath: Path):
         self.filepath = filepath
@@ -212,6 +213,9 @@ class ISOGame(Game):
             return self.GameStatus.OK
 
     def rename(self, new_title: str) -> None:
+        if new_title is None:
+            return
+
         if len(new_title) > 32:
             print(f"Title {new_title} is too long!",
                   file=sys.stderr)
@@ -269,6 +273,84 @@ class ISOGame(Game):
 
     def delete_game(self, opl_dir: Path):
         print("Deleting ISO file...")
+        self.filepath.unlink()
+        print("Done!")
+        super().delete_game(opl_dir)
+
+
+class ZSOGame(Game):
+    GameStatus = Enum("GameStatus", ["WRONG_FILENAME", "OK"])
+
+    def __init__(self, filepath: Path):
+        self.game_format = GameFormat.ZSO
+        self.filetype = "ZSO"
+        super().__init__(filepath)
+        self.get_filedata()
+
+    def check_status(self) -> GameStatus:
+        if not self.proper_filename_regex.findall(self.filename):
+            return self.GameStatus.WRONG_FILENAME
+        else:
+            return self.GameStatus.OK
+
+    def rename(self, new_title: str) -> None:
+        if new_title is None:
+            return
+
+        if len(new_title) > 32:
+            print(f"Title {new_title} is too long!",
+                  file=sys.stderr)
+            print(
+                "Titles longer than 32 characters are not permitted!", file=sys.stderr)
+            print(f"Skipping {self.opl_id}...", file=sys.stderr)
+            return
+
+        new_filename = f"{self.opl_id}.{new_title}.{self.filetype}"
+        new_filepath = self.filepath.parent.joinpath(
+            new_filename
+        )
+        self.filepath = self.filepath.rename(new_filepath)
+
+        new_filepath.chmod(0o777)
+
+        self.title = new_title
+        print(
+            f"The game \'{self.opl_id}\' was renamed to \'{self.title}\'")
+
+    def fix_issues(self, status: GameStatus) -> None:
+        if status == self.GameStatus.WRONG_FILENAME:
+            print(f"Fixing '{self.filename}'...")
+            self.filepath = self.filepath.rename(
+                self.filedir.joinpath(f"{self.opl_id}.{self.title}.{self.filetype}")
+            )
+
+            self.filepath.chmod(0o777)
+            self.filename = self.filepath.name
+            self.gen_opl_id()
+            self.print_data()
+        elif status == self.GameStatus.OK:
+            pass
+
+    def get_filedata(self) -> None:
+        if (res := REGION_CODE_REGEX_STR.findall(self.filename)):
+            self.id = res[0]
+        else:
+            raise ValueError(
+                f"Cannot find Game ID in filename '{self.filename}'. ZSO files must be properly named.")
+
+        if not self.id:
+            return
+
+        self.gen_opl_id()
+        self.size = self.filepath.stat().st_size / (1024 ** 2)
+
+        self.title = REGION_CODE_REGEX_STR.sub('', self.filename)
+        self.title = re.sub(r".[zZ][sS][oO]", "", self.title)
+        self.title = self.title.strip('._- ')
+        self.filename = re.sub(r".[zZ][sS][oO]", "", self.filename)
+
+    def delete_game(self, opl_dir: Path):
+        print("Deleting ZSO file...")
         self.filepath.unlink()
         print("Done!")
         super().delete_game(opl_dir)
@@ -342,6 +424,9 @@ class POPSGame(Game):
 
 
     def rename(self, new_title: str) -> None:
+        if new_title is None:
+            return
+
         if len(new_title) > 32:
             print(f"Title {new_title} is too long!",
                   file=sys.stderr)

--- a/pyoplm/opl/args.py
+++ b/pyoplm/opl/args.py
@@ -24,6 +24,7 @@ class OPLMCommand:
     FIX = 5
     INIT = 6
     DELETE = 7
+    CONVERT = 8
 
 
 class BinToolsCommand:
@@ -50,6 +51,8 @@ def handle_oplm_commands(opl_dir: Path, cmd: OPLMCommand, **kwargs):
         opl.rename(**kwargs, storage=True)
     elif cmd == OPLMCommand.ST_ARTWORK:
         opl.artwork(**kwargs)
+    elif cmd == OPLMCommand.CONVERT:
+        opl.convert(**kwargs)
 
 
 def handle_bintools_commands(cmd: BinToolsCommand, **kwargs):
@@ -91,6 +94,8 @@ def add_parser(subparsers):
         "--iso", "-i", help="Don't do UL conversion", action="store_true")
     parser.add_argument(
         "--storage", "-s", help="Get title and artwork from storage if it's enabled", action="store_true")
+    parser.add_argument(
+        "--zso", "-z", help="Compress to ZSO format before installing", action="store_true")
     parser.add_argument(
         "opl_dir", help="Path to your OPL directory",
         type=Path, nargs="?")
@@ -199,6 +204,19 @@ def storage_parser(subparsers):
     return subparsers
 
 
+def convert_parser(subparsers):
+    parser = subparsers.add_parser(
+        "convert", help="Convert between ISO and ZSO formats")
+    parser.add_argument(
+        "--to-zso", help="Convert ISO to ZSO", action="store_true")
+    parser.add_argument(
+        "--to-iso", help="Convert ZSO to ISO", action="store_true")
+    parser.add_argument(
+        "file", help="File to convert", type=Path)
+    parser.set_defaults(kind=SubparserKind.OPLM, cmd=OPLMCommand.CONVERT)
+    return subparsers
+
+
 def bintools_parser(subparsers):
     def bchunk_parser(subparsers):
         parser = subparsers.add_parser(
@@ -258,7 +276,7 @@ def main_parser():
 
     subparsers = parser.add_subparsers(help="Choose your path...")
     parser_list = [list_parser, rename_parser, delete_parser,
-                   fix_parser, init_parser, add_parser, storage_parser, bintools_parser]
+                    fix_parser, init_parser, add_parser, storage_parser, convert_parser, bintools_parser]
 
     # Attach all parsers to the subparsers object
     subparsers = reduce(lambda x, y: y(x), parser_list, subparsers)

--- a/pyoplm/opl/args.py
+++ b/pyoplm/opl/args.py
@@ -207,9 +207,10 @@ def storage_parser(subparsers):
 def convert_parser(subparsers):
     parser = subparsers.add_parser(
         "convert", help="Convert between ISO and ZSO formats")
-    parser.add_argument(
+    direction = parser.add_mutually_exclusive_group(required=True)
+    direction.add_argument(
         "--to-zso", help="Convert ISO to ZSO", action="store_true")
-    parser.add_argument(
+    direction.add_argument(
         "--to-iso", help="Convert ZSO to ISO", action="store_true")
     parser.add_argument(
         "file", help="File to convert", type=Path)

--- a/pyoplm/opl/games_manager.py
+++ b/pyoplm/opl/games_manager.py
@@ -10,7 +10,8 @@ from pyoplm.bintools import install_ps2_cue, psx_add
 
 from ..ul import ULConfig
 from ..common import get_iso_id, path_to_ul_cfg
-from ..game import Game, ISOGame, ULGame, POPSGame
+from ..game import Game, ISOGame, ULGame, POPSGame, ZSOGame
+from ..zso import compress as compress_zso, decompress as decompress_zso
 from itertools import chain
 
 
@@ -36,10 +37,17 @@ class GamesManager():
         path2 = self.opl_dir.joinpath("CD")
         return chain(path1.glob(extension_pattern), path2.glob(extension_pattern))
 
+    def __get_zso_game_files(self) -> Iterator[Path]:
+        extension_pattern = "*.[zZ][sS][oO]"
+        path1 = self.opl_dir.joinpath("DVD")
+        path2 = self.opl_dir.joinpath("CD")
+        return chain(path1.glob(extension_pattern), path2.glob(extension_pattern))
+
     def __initialize_games(self):
         game_to_files_func = [
             (POPSGame, self.__get_pops_game_files, "pops_games"),
             (ISOGame, self.__get_iso_game_files, "iso_games"),
+            (ZSOGame, self.__get_zso_game_files, "zso_games"),
         ]
         for (game_type, get_files, dest_list) in game_to_files_func:
             files = get_files()
@@ -67,6 +75,7 @@ class GamesManager():
     def list(self) -> None:
         games_and_kinds: Dict[str, Iterator[Game]] = {
             "ISO": self.iso_games,
+            "ZSO": self.zso_games,
             "UL": self.ul_games,
             "POPS": self.pops_games
         }
@@ -91,7 +100,7 @@ class GamesManager():
             sys.exit(1)
 
     # Installs game to OPL directory, returns the Game subclass object representing the added game
-    def add(self, game_path: Path, psx=False, iso=False, ul=False, force=False) -> Game:
+    def add(self, game_path: Path, psx=False, iso=False, ul=False, force=False, zso=False) -> Game:
         if psx:
             print("Installing POPS game...")
             if game := psx_add(game_path, self.opl_dir):
@@ -130,15 +139,49 @@ class GamesManager():
                     print(
                         f"Game title \'{title}\' is longer than 32 characters, skipping...")
                     sys.exit(1)
-                new_game_path: Path = self.opl_dir.joinpath(
-                    "DVD" if game_size > 700 else "CD",
-                    f"{iso_id}.{title}.iso")
 
-                print(
-                    f"Copying game to \'{new_game_path}\', please wait...")
-                copyfile(game_path, new_game_path)
-                new_game_path.chmod(0o777)
-                print("Done!")
+                if zso:
+                    new_game_path: Path = self.opl_dir.joinpath(
+                        "DVD" if game_size > 700 else "CD",
+                        f"{iso_id}.{title}.zso")
 
-                return ISOGame(new_game_path)
+                    print(
+                        f"Compressing game to \'{new_game_path}\', please wait...")
+                    compress_zso(game_path, new_game_path)
+                    new_game_path.chmod(0o777)
+                    print("Done!")
+
+                    return ZSOGame(new_game_path)
+                else:
+                    new_game_path: Path = self.opl_dir.joinpath(
+                        "DVD" if game_size > 700 else "CD",
+                        f"{iso_id}.{title}.iso")
+
+                    print(
+                        f"Copying game to \'{new_game_path}\', please wait...")
+                    copyfile(game_path, new_game_path)
+                    new_game_path.chmod(0o777)
+                    print("Done!")
+
+                    return ISOGame(new_game_path)
         sys.exit(0)
+
+    def convert(self, file_path: Path, to_zso: bool = True) -> None:
+        if to_zso:
+            if file_path.suffix.lower() not in ['.iso', '.vcd']:
+                print(f"Source file must be an ISO or VCD, got '{file_path.suffix}'", file=sys.stderr)
+                sys.exit(1)
+
+            zso_path = file_path.with_suffix('.zso')
+            print(f"Compressing '{file_path}' to '{zso_path}'...")
+            compress_zso(file_path, zso_path)
+            print("Done!")
+        else:
+            if file_path.suffix.lower() != '.zso':
+                print(f"Source file must be a ZSO, got '{file_path.suffix}'", file=sys.stderr)
+                sys.exit(1)
+
+            iso_path = file_path.with_suffix('.iso')
+            print(f"Decompressing '{file_path}' to '{iso_path}'...")
+            decompress_zso(file_path, iso_path)
+            print("Done!")

--- a/pyoplm/opl/games_manager.py
+++ b/pyoplm/opl/games_manager.py
@@ -50,11 +50,14 @@ class GamesManager():
             (ZSOGame, self.__get_zso_game_files, "zso_games"),
         ]
         for (game_type, get_files, dest_list) in game_to_files_func:
-            files = get_files()
-            games = {
-                game.opl_id: game
-                for game in (game_type(file) for file in files)
-            }
+            games = {}
+            for file in get_files():
+                try:
+                    game = game_type(file)
+                except (ValueError, OSError) as e:
+                    print(f"Skipping '{file}': {e}", file=sys.stderr)
+                    continue
+                games[game.opl_id] = game
             self.games_dict.update(games)
 
             setattr(self, dest_list, iter(games.values()))
@@ -168,11 +171,16 @@ class GamesManager():
 
     def convert(self, file_path: Path, to_zso: bool = True) -> None:
         if to_zso:
-            if file_path.suffix.lower() not in ['.iso', '.vcd']:
-                print(f"Source file must be an ISO or VCD, got '{file_path.suffix}'", file=sys.stderr)
+            if file_path.suffix.lower() != '.iso':
+                print(f"Source file must be an ISO, got '{file_path.suffix}'", file=sys.stderr)
                 sys.exit(1)
 
             zso_path = file_path.with_suffix('.zso')
+            if zso_path.exists():
+                print(
+                    f"'{zso_path}' already exists, not overwriting", file=sys.stderr)
+                sys.exit(1)
+
             print(f"Compressing '{file_path}' to '{zso_path}'...")
             compress_zso(file_path, zso_path)
             print("Done!")
@@ -182,6 +190,11 @@ class GamesManager():
                 sys.exit(1)
 
             iso_path = file_path.with_suffix('.iso')
+            if iso_path.exists():
+                print(
+                    f"'{iso_path}' already exists, not overwriting", file=sys.stderr)
+                sys.exit(1)
+
             print(f"Decompressing '{file_path}' to '{iso_path}'...")
             decompress_zso(file_path, iso_path)
             print("Done!")

--- a/pyoplm/opl/pyoplm_manager.py
+++ b/pyoplm/opl/pyoplm_manager.py
@@ -60,9 +60,10 @@ class PyOPLManager:
     #  - otherwise just copy with OPL-like filename
     #  - If storage features are enabled, try to get title from storage and download artwork
 
-    def add(self, src_files: List[Path], psx=False, iso=False, ul=False, force=False, storage=False):
+    def add(self, src_files: List[Path], psx=False, iso=False, ul=False, force=False, storage=False, zso=False):
         for game_path in src_files:
-            game = self.games_manager.add(game_path, psx, iso, ul, force)
+            game = self.games_manager.add(
+                game_path, psx, iso, ul, force, zso=zso)
 
             if self.storage.is_enabled() and storage:
                 self.storage.get_artwork_for_game(game.opl_id, True)

--- a/pyoplm/opl/pyoplm_manager.py
+++ b/pyoplm/opl/pyoplm_manager.py
@@ -121,3 +121,6 @@ class PyOPLManager:
                 dir.mkdir(0o777)
         self.opl_dir.joinpath("ul.cfg").touch(0o777)
         print("Done!")
+
+    def convert(self, file: Path, to_zso=False, to_iso=False):
+        self.games_manager.convert(file, to_zso=to_zso)

--- a/pyoplm/zso.py
+++ b/pyoplm/zso.py
@@ -1,0 +1,134 @@
+import lz4.block
+from struct import pack, unpack
+from pathlib import Path
+
+ZSO_MAGIC = 0x4F53495A
+ZSO_HEADER_SIZE = 0x18
+DEFAULT_BLOCK_SIZE = 0x800
+COMPRESS_THRESHOLD = 95
+DEFAULT_PADDING = b'X'
+
+
+def lz4_compress(plain: bytes, level: int = 2) -> bytes:
+    mode = "high_compression" if level > 1 else "default"
+    return lz4.block.compress(plain, mode=mode, compression=level, store_size=False)
+
+
+def lz4_decompress(compressed: bytes, block_size: int) -> bytes:
+    decompressed = None
+    while True:
+        try:
+            decompressed = lz4.block.decompress(
+                compressed, uncompressed_size=block_size)
+            break
+        except lz4.block.LZ4BlockError:
+            compressed = compressed[:-1]
+    return decompressed
+
+
+def read_zso_header(fin) -> tuple:
+    fin.seek(0)
+    data = fin.read(ZSO_HEADER_SIZE)
+    magic, header_size, total_bytes, block_size, ver, align = unpack(
+        'IIQIbbxx', data)
+    return magic, header_size, total_bytes, block_size, ver, align
+
+
+def generate_zso_header(total_bytes: int, block_size: int, ver: int, align: int) -> bytes:
+    return pack('IIQIbbxx', ZSO_MAGIC, ZSO_HEADER_SIZE, total_bytes, block_size, ver, align)
+
+
+def set_align(fout, write_pos: int, align: int) -> int:
+    if write_pos % (1 << align):
+        align_len = (1 << align) - write_pos % (1 << align)
+        fout.write(DEFAULT_PADDING * align_len)
+        write_pos += align_len
+    return write_pos
+
+
+def compress(iso_path: Path, zso_path: Path, level: int = 2) -> None:
+    with open(iso_path, "rb") as fin, open(zso_path, "wb") as fout:
+        fin.seek(0, 2)
+        total_bytes = fin.tell()
+        fin.seek(0)
+
+        block_size = DEFAULT_BLOCK_SIZE
+        align = total_bytes // 2 ** 31
+        ver = 1
+
+        header = generate_zso_header(total_bytes, block_size, ver, align)
+        fout.write(header)
+
+        total_block = total_bytes // block_size
+        index_buf = [0 for _ in range(total_block + 1)]
+
+        fout.write(b"\x00\x00\x00\x00" * len(index_buf))
+
+        write_pos = fout.tell()
+        block = 0
+
+        while block < total_block:
+            iso_data = fin.read(block_size)
+            zso_data = lz4_compress(iso_data, level)
+
+            write_pos = set_align(fout, write_pos, align)
+            index_buf[block] = write_pos >> align
+
+            if 100 * len(zso_data) / len(iso_data) >= COMPRESS_THRESHOLD:
+                zso_data = iso_data
+                index_buf[block] |= 0x80000000
+            elif index_buf[block] & 0x80000000:
+                raise ValueError(
+                    "Align error, you have to increase align by 1 or OPL won't be able to read offset above 2**31 bytes")
+
+            fout.write(zso_data)
+            write_pos += len(zso_data)
+            block += 1
+
+        index_buf[block] = write_pos >> align
+
+        fout.seek(ZSO_HEADER_SIZE)
+        for i in index_buf:
+            fout.write(pack('I', i))
+
+
+def decompress(zso_path: Path, iso_path: Path) -> None:
+    with open(zso_path, "rb") as fin, open(iso_path, "wb") as fout:
+        magic, header_size, total_bytes, block_size, ver, align = read_zso_header(fin)
+
+        if magic != ZSO_MAGIC or block_size == 0 or total_bytes == 0 or header_size != 24 or ver > 1:
+            raise ValueError("zso file format error")
+
+        total_block = total_bytes // block_size
+
+        fin.seek(ZSO_HEADER_SIZE)
+        index_buf = [unpack('I', fin.read(4))[0] for _ in range(total_block + 1)]
+
+        block = 0
+        while block < total_block:
+            index = index_buf[block]
+            plain = index & 0x80000000
+            index &= 0x7fffffff
+            read_pos = index << (align)
+
+            if plain:
+                read_size = block_size
+            else:
+                index2 = index_buf[block + 1] & 0x7fffffff
+                read_size = (index2 - index) << (align)
+                if block == total_block - 1:
+                    read_size = total_bytes - read_pos
+
+            fin.seek(read_pos)
+            zso_data = fin.read(read_size)
+
+            if plain:
+                dec_data = zso_data
+            else:
+                dec_data = lz4_decompress(zso_data, block_size)
+
+            if len(dec_data) != block_size:
+                raise ValueError(f"Block {block}: decompressed size mismatch")
+
+            fout.write(dec_data)
+            block += 1

--- a/pyoplm/zso.py
+++ b/pyoplm/zso.py
@@ -16,11 +16,12 @@ def lz4_compress(plain: bytes, level: int = 2) -> bytes:
 
 def lz4_decompress(compressed: bytes, block_size: int) -> bytes:
     decompressed = None
-    while True:
+    while decompressed is None:
+        if not compressed:
+            raise ValueError("Corrupt ZSO block, cannot decompress")
         try:
             decompressed = lz4.block.decompress(
                 compressed, uncompressed_size=block_size)
-            break
         except lz4.block.LZ4BlockError:
             compressed = compressed[:-1]
     return decompressed
@@ -51,6 +52,11 @@ def compress(iso_path: Path, zso_path: Path, level: int = 2) -> None:
         fin.seek(0, 2)
         total_bytes = fin.tell()
         fin.seek(0)
+
+        if total_bytes % DEFAULT_BLOCK_SIZE:
+            raise ValueError(
+                f"Input size {total_bytes} is not a multiple of the "
+                f"{DEFAULT_BLOCK_SIZE} byte ZSO block size")
 
         block_size = DEFAULT_BLOCK_SIZE
         align = total_bytes // 2 ** 31

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,6 @@ Homepage = "https://github.com/edisnord/pyoplm"
 [project.scripts]
 pyoplm = "pyoplm:main"
 
-[tool.pytest.ini_options]
-markers = [
-    "integration: tests that hit the real archive.org dump (slow)",
-]
-
 # [tool.hatch.build.targets.sdist]
 # include = [
 #     "pyoplm/lib/linux64/bchunk/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ requires-python = ">=3.10"
 dependencies = [
     "pillow>=11.0",
     "beautifulsoup4==4.12.2",
-    "lxml"
+    "lxml",
+    "lz4"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -28,6 +29,11 @@ Homepage = "https://github.com/edisnord/pyoplm"
 
 [project.scripts]
 pyoplm = "pyoplm:main"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests that hit the real archive.org dump (slow)",
+]
 
 # [tool.hatch.build.targets.sdist]
 # include = [

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setuptools.setup(
     install_requires=[
         "pillow==9.4.0",
         "beautifulsoup4==4.12.2",
-        "lxml"
+        "lxml",
+        "lz4"
     ],
     package_data={"": ["pyoplm/lib/linux64/bchunk/*"],
                   "": ["pyoplm/lib/linux64/binmerge/*"],


### PR DESCRIPTION
## Issue #5: Add support for ZSO format

### Overview
ZSO is a compressed ISO format (LZ4) supported by OPL 1.2.0+. This PR adds full ZSO support to PyOPLM.

### New Features

**Install as ZSO:**
```bash
pyoplm add --zso game.iso
```

**Convert between formats:**
```bash
pyoplm convert --to-zso game.iso   # ISO → ZSO
pyoplm convert --to-iso game.zso   # ZSO → ISO
```

**Automatic discovery:** ZSO files in `CD/` and `DVD/` folders are automatically detected and listed.

### Changes
| File | Change |
|------|--------|
| `pyoplm/zso.py` | **New** — compression/decompression library (adapted from OPL's ziso.py) |
| `pyoplm/game.py` | `ZSOGame` class, `GameFormat.ZSO` enum, updated filename regex |
| `pyoplm/opl/games_manager.py` | ZSO discovery, `--zso` flag in `add()`, `convert()` method |
| `pyoplm/opl/args.py` | `--zso` flag on `add`, new `convert` command |
| `pyoplm/opl/pyoplm_manager.py` | `convert()` routing |
| `pyproject.toml`, `setup.py` | `lz4` dependency |

### Notes
- ZSO files must be properly named (e.g., `SLUS_205.62.GameTitle.zso`) since game IDs cannot be extracted from compressed data
- Compression uses level 2 by default (matching OPL documentation)
- ZSO files stored in `CD/` or `DVD/` alongside ISOs (same 700MB threshold)